### PR TITLE
Issue #3193195 by abrar_arshad, fgm: avoid log failures on PHP 5 closures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_script:
 
   # install dependencies (for the module) and Coveralls (for coverage) as part of the root vendors. Get rid of PHPunit < 7 and locked dependencies.
   - rm -fr composer.lock vendor
-  - composer require -v "drush/drush:^10" drupal/console "mongodb/mongodb:^1.5.1" "phpunit/phpunit:^8.5" $COVERALLS
+  - composer require -v "drush/drush:^10" drupal/console "mongodb/mongodb:^1.5.1" "phpunit/phpunit:^8.5.18" $COVERALLS
   - composer show mongodb/mongodb
 
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
   "name": "drupal/mongodb",
   "prefer-stable": false,
   "require": {
-    "php": ">=7.3.0",
+    "php": ">=7.4.0",
     "ext-json": "*",
     "ext-mongodb": "^1.5.1",
     "mongodb/mongodb": "^1.5.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5",
-    "squizlabs/php_codesniffer": "^3.5"
+    "phpunit/phpunit": "^8.5.18",
+    "squizlabs/php_codesniffer": "^3.6.0"
   },
   "support": {
     "docs": "https://github.com/fgm/mongodb/blob/8.x-2.x/README.md",

--- a/modules/mongodb/mongodb.install
+++ b/modules/mongodb/mongodb.install
@@ -5,7 +5,7 @@
  * Install file for the MongoDB module.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * Requirements check: MongoDB extension.

--- a/modules/mongodb/mongodb.module
+++ b/modules/mongodb/mongodb.module
@@ -5,7 +5,7 @@
  * Contains the main module connecting Drupal to MongoDB.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * Implements hook_help().

--- a/modules/mongodb/src/ClientFactory.php
+++ b/modules/mongodb/src/ClientFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb;
 
@@ -8,7 +8,7 @@ use Drupal\Core\Site\Settings;
 use MongoDB\Client;
 
 /**
- * Class ClientFactory.
+ * Helper class to construct a MongoDB client with Drupal specific config.
  */
 class ClientFactory {
 

--- a/modules/mongodb/src/Command/FindCommand.php
+++ b/modules/mongodb/src/Command/FindCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb\Command;
 
@@ -14,7 +14,7 @@ use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Annotations\DrupalCommand;
 
 /**
- * Class FindCommand.
+ * Class FindCommand provides the 'commands.mongodb.find' command.
  *
  * @DrupalCommand (
  *     extension="mongodb",

--- a/modules/mongodb/src/Command/SettingsCommand.php
+++ b/modules/mongodb/src/Command/SettingsCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb\Command;
 
@@ -13,7 +13,7 @@ use Drupal\Console\Core\Command\ContainerAwareCommand;
 use Drupal\Console\Annotations\DrupalCommand;
 
 /**
- * Class SettingsCommand.
+ * Class SettingsCommand provides the 'commands.mongodb.settings' command.
  *
  * @DrupalCommand (
  *     extension="mongodb",

--- a/modules/mongodb/src/Commands/MongodbCommands.php
+++ b/modules/mongodb/src/Commands/MongodbCommands.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb\Commands;
 

--- a/modules/mongodb/src/DatabaseFactory.php
+++ b/modules/mongodb/src/DatabaseFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb;
 
@@ -8,7 +8,7 @@ use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Site\Settings;
 
 /**
- * Class DatabaseFactory.
+ * Helper class to construct a MongoDB Database with Drupal specific config.
  *
  * @package Drupal\mongodb
  */

--- a/modules/mongodb/src/Install/Tools.php
+++ b/modules/mongodb/src/Install/Tools.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb\Install;
 

--- a/modules/mongodb/src/MongoDb.php
+++ b/modules/mongodb/src/MongoDb.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb;
 

--- a/modules/mongodb/tests/src/Kernel/ClientFactoryTest.php
+++ b/modules/mongodb/tests/src/Kernel/ClientFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb\Kernel;
 
@@ -9,7 +9,7 @@ use Drupal\mongodb\ClientFactory;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
 
 /**
- * Class ClientFactoryTest.
+ * Tests the ClientFactory.
  *
  * @coversDefaultClass \Drupal\mongodb\ClientFactory
  *

--- a/modules/mongodb/tests/src/Kernel/DatabaseFactoryTest.php
+++ b/modules/mongodb/tests/src/Kernel/DatabaseFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb\Kernel;
 
@@ -10,7 +10,7 @@ use Drupal\mongodb\MongoDb;
 use MongoDB\Database;
 
 /**
- * Class DatabaseFactoryTest.
+ * Tests the DatabaseFactory.
  *
  * @coversDefaultClass \Drupal\mongodb\DatabaseFactory
  *

--- a/modules/mongodb/tests/src/Kernel/MongoDbTest.php
+++ b/modules/mongodb/tests/src/Kernel/MongoDbTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb\Kernel;
 
@@ -8,7 +8,7 @@ use Drupal\mongodb\MongoDb;
 use MongoDB\Collection;
 
 /**
- * Class CommandsTest.
+ * Tests the MongoDB main class.
  *
  * @coversDefaultClass \Drupal\mongodb\MongoDb
  *

--- a/modules/mongodb/tests/src/Kernel/MongoDbTestBase.php
+++ b/modules/mongodb/tests/src/Kernel/MongoDbTestBase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb\Kernel;
 
@@ -16,13 +16,19 @@ use Drupal\mongodb\MongoDb;
  * @group MongoDB
  */
 abstract class MongoDbTestBase extends KernelTestBase {
+
   const DEFAULT_URI = 'mongodb://localhost:27017';
+
   const CLIENT_BAD_ALIAS = 'bad';
+
   const CLIENT_TEST_ALIAS = 'test';
 
   const DB_BAD_CLIENT_ALIAS = 'bad';
+
   const DB_INVALID_ALIAS = 'invalid';
+
   const DB_DEFAULT_ALIAS = 'default';
+
   const DB_UNSET_ALIAS = 'unset';
 
   /**
@@ -65,7 +71,7 @@ abstract class MongoDbTestBase extends KernelTestBase {
    * @return array
    *   A settings array only containing MongoDB-related settings.
    */
-  protected function getSettingsArray() : array {
+  protected function getSettingsArray(): array {
     return [
       'clients' => [
         static::CLIENT_BAD_ALIAS => [
@@ -80,9 +86,18 @@ abstract class MongoDbTestBase extends KernelTestBase {
         ],
       ],
       'databases' => [
-        static::DB_DEFAULT_ALIAS => [static::CLIENT_TEST_ALIAS, $this->getDatabasePrefix()],
-        static::DB_INVALID_ALIAS => [static::CLIENT_TEST_ALIAS, ''],
-        static::DB_BAD_CLIENT_ALIAS => [static::CLIENT_BAD_ALIAS, $this->getDatabasePrefix()],
+        static::DB_DEFAULT_ALIAS => [
+          static::CLIENT_TEST_ALIAS,
+          $this->getDatabasePrefix(),
+        ],
+        static::DB_INVALID_ALIAS => [
+          static::CLIENT_TEST_ALIAS,
+          '',
+        ],
+        static::DB_BAD_CLIENT_ALIAS => [
+          static::CLIENT_BAD_ALIAS,
+          $this->getDatabasePrefix(),
+        ],
       ],
     ];
   }

--- a/modules/mongodb/tests/src/Kernel/ToolsTest.php
+++ b/modules/mongodb/tests/src/Kernel/ToolsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb\Kernel;
 

--- a/modules/mongodb_storage/src/Command/SqlImportCommand.php
+++ b/modules/mongodb_storage/src/Command/SqlImportCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage\Command;
 
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class SqlImportCommand.
+ * Provides the commands.mongodb.storage.import_keyvalue console command.
  *
  * @DrupalCommand (
  *     extension="mongodb_storage",

--- a/modules/mongodb_storage/src/Commands/MongoDbStorageCommands.php
+++ b/modules/mongodb_storage/src/Commands/MongoDbStorageCommands.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage\Commands;
 

--- a/modules/mongodb_storage/src/Install/SqlImport.php
+++ b/modules/mongodb_storage/src/Install/SqlImport.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage\Install;
 

--- a/modules/mongodb_storage/src/KeyValueExpirableFactory.php
+++ b/modules/mongodb_storage/src/KeyValueExpirableFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage;
 

--- a/modules/mongodb_storage/src/KeyValueFactory.php
+++ b/modules/mongodb_storage/src/KeyValueFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage;
 

--- a/modules/mongodb_storage/src/KeyValueStore.php
+++ b/modules/mongodb_storage/src/KeyValueStore.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage;
 

--- a/modules/mongodb_storage/src/KeyValueStoreExpirable.php
+++ b/modules/mongodb_storage/src/KeyValueStoreExpirable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage;
 

--- a/modules/mongodb_storage/src/Storage.php
+++ b/modules/mongodb_storage/src/Storage.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_storage;
 

--- a/modules/mongodb_storage/tests/src/Kernel/KeyValueFactoryTest.php
+++ b/modules/mongodb_storage/tests/src/Kernel/KeyValueFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb_storage\Kernel;
 
@@ -9,7 +9,7 @@ use Drupal\mongodb_storage\KeyValueStoreExpirable;
 use Drupal\mongodb_storage\Storage;
 
 /**
- * Class KeyValueFactoryTest.
+ * Tests the KeyValueFactory.
  *
  * @coversDefaultClass \Drupal\mongodb_storage\KeyValueFactory
  *

--- a/modules/mongodb_storage/tests/src/Kernel/KeyValueTestBase.php
+++ b/modules/mongodb_storage/tests/src/Kernel/KeyValueTestBase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb_storage\Kernel;
 
@@ -29,6 +29,9 @@ abstract class KeyValueTestBase extends MongoDbTestBase {
     Storage::MODULE,
   ];
 
+  /**
+   * {@inheritDoc}
+   */
   public function setUp(): void {
     parent::setUp();
 

--- a/modules/mongodb_storage/tests/src/Kernel/SqlImportTest.php
+++ b/modules/mongodb_storage/tests/src/Kernel/SqlImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb_storage\Kernel;
 
@@ -11,10 +11,9 @@ use Drupal\mongodb_storage\Install\SqlImport;
 use Drupal\mongodb_storage\KeyValueExpirableFactory;
 use Drupal\mongodb_storage\KeyValueFactory;
 use Drupal\mongodb_storage\Storage;
-use Drupal\views\Plugin\views\query\Sql;
 
 /**
- * Class SqlImportTest.
+ * Tests the import for the commands.mongodb.storage.import_keyvalue command.
  *
  * @coversDefaultClass \Drupal\mongodb_storage\Install\SqlImport
  *
@@ -153,9 +152,11 @@ class SqlImportTest extends KeyValueTestBase {
       case SqlImport::KVE_TABLE:
         $columns = array_keys(DatabaseStorageExpirable::schemaDefinition()['fields']);
         break;
+
       case SqlImport::KVP_TABLE:
         $columns = array_keys(DatabaseStorage::schemaDefinition()['fields']);
         break;
+
       default:
         $this->fail("Unexpected table requested: ${table}.");
     }

--- a/modules/mongodb_watchdog/src/Command/SanityCheckCommand.php
+++ b/modules/mongodb_watchdog/src/Command/SanityCheckCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Command;
 
@@ -8,12 +8,12 @@ use Drupal\Component\Serialization\Yaml;
 // @codingStandardsIgnoreLine
 use Drupal\Console\Annotations\DrupalCommand;
 use Drupal\Console\Core\Command\ContainerAwareCommand;
-use Drupal\mongodb_watchdog\Install\Sanitycheck;
+use Drupal\mongodb_watchdog\Install\SanityCheck;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class SanityCheckCommand.
+ * Class SanityCheckCommand provides the mongodb:watchdog:sanitycheck command.
  *
  * @DrupalCommand (
  *     extension="mongodb_watchdog",
@@ -25,7 +25,7 @@ class SanityCheckCommand extends ContainerAwareCommand {
   /**
    * The mongodb.watchdog.sanity_check service.
    *
-   * @var \Drupal\mongodb_watchdog\Install\Sanitycheck
+   * @var \Drupal\mongodb_watchdog\Install\SanityCheck
    */
   protected $sanityCheck;
 

--- a/modules/mongodb_watchdog/src/Commands/MongoDbWatchdogCommands.php
+++ b/modules/mongodb_watchdog/src/Commands/MongoDbWatchdogCommands.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Commands;
 
-use Drupal\mongodb_watchdog\Install\Sanitycheck;
+use Drupal\mongodb_watchdog\Install\SanityCheck;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -15,17 +15,17 @@ class MongoDbWatchdogCommands extends DrushCommands {
   /**
    * The mongodb.watchdog.sanity_check service.
    *
-   * @var \Drupal\mongodb_watchdog\Install\Sanitycheck
+   * @var \Drupal\mongodb_watchdog\Install\SanityCheck
    */
   protected $sanityCheck;
 
   /**
    * MongodbWatchdogCommands constructor.
    *
-   * @param \Drupal\mongodb_watchdog\Install\Sanitycheck $sanityCheck
+   * @param \Drupal\mongodb_watchdog\Install\SanityCheck $sanityCheck
    *   The mongodb.watchdog.sanity_check service.
    */
-  public function __construct(Sanitycheck $sanityCheck) {
+  public function __construct(SanityCheck $sanityCheck) {
     $this->sanityCheck = $sanityCheck;
   }
 

--- a/modules/mongodb_watchdog/src/Controller/ControllerBase.php
+++ b/modules/mongodb_watchdog/src/Controller/ControllerBase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Controller;
 
@@ -157,7 +157,7 @@ abstract class ControllerBase extends CoreControllerBase {
    * @return int
    *   The actual index of the page to display.
    */
-  public static function getPage(float $count, int $requestedPage, int $height): int {
+  public static function getPage(int $count, int $requestedPage, int $height): int {
     if ($requestedPage <= 0) {
       return 0;
     }

--- a/modules/mongodb_watchdog/src/Controller/DetailController.php
+++ b/modules/mongodb_watchdog/src/Controller/DetailController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Controller;
 
@@ -135,7 +135,7 @@ class DetailController extends ControllerBase {
     $rows = [];
 
     foreach ($events as $event) {
-      // TODO bring this back from "model": it is a display method.
+      // @todo bring this back from "model": it is a display method.
       $rows[] = $this->eventController->asTableRow($eventTemplate, $event);
     }
 

--- a/modules/mongodb_watchdog/src/Controller/OverviewController.php
+++ b/modules/mongodb_watchdog/src/Controller/OverviewController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Controller;
 

--- a/modules/mongodb_watchdog/src/Controller/RequestController.php
+++ b/modules/mongodb_watchdog/src/Controller/RequestController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Controller;
 
@@ -86,8 +86,8 @@ class RequestController extends ControllerBase {
    *   A render array.
    */
   public function build(Request $request, string $uniqueId): array {
-    if (!preg_match('/^[\w-@]+$/', $uniqueId)) {
-      throw new NotFoundHttpException($this->t('Request ID is not well-formed.'));
+    if (!preg_match('/^[-\w@]+$/', $uniqueId)) {
+      throw new NotFoundHttpException('Request ID is not well-formed.');
     }
 
     $events = $this->getRowData($request, $uniqueId);

--- a/modules/mongodb_watchdog/src/Controller/TopController.php
+++ b/modules/mongodb_watchdog/src/Controller/TopController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Controller;
 

--- a/modules/mongodb_watchdog/src/Event.php
+++ b/modules/mongodb_watchdog/src/Event.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog;
 
@@ -8,7 +8,7 @@ use Drupal\Core\Logger\RfcLogLevel;
 use MongoDB\BSON\Unserializable;
 
 /**
- * Class Event.
+ * Class Event is a value object for a logged event.
  *
  * @package Drupal\mongodb_watchdog
  *

--- a/modules/mongodb_watchdog/src/EventController.php
+++ b/modules/mongodb_watchdog/src/EventController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog;
 

--- a/modules/mongodb_watchdog/src/EventTemplate.php
+++ b/modules/mongodb_watchdog/src/EventTemplate.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog;
 

--- a/modules/mongodb_watchdog/src/EventTemplateConverter.php
+++ b/modules/mongodb_watchdog/src/EventTemplateConverter.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog;
 
@@ -46,7 +46,9 @@ class EventTemplateConverter implements ParamConverterInterface {
    */
   public function convert($value, $definition, $name, array $defaults): ?EventTemplate {
     if (!is_string($value)) {
-      $this->logger->notice('Non-string event template id: %id', ['%id' => var_export($value, TRUE)]);
+      $this->logger->notice('Non-string event template id: %id', [
+        '%id' => var_export($value, TRUE),
+      ]);
       return NULL;
     }
 

--- a/modules/mongodb_watchdog/src/Form/ClearConfirmForm.php
+++ b/modules/mongodb_watchdog/src/Form/ClearConfirmForm.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Form;
 

--- a/modules/mongodb_watchdog/src/Form/ConfigForm.php
+++ b/modules/mongodb_watchdog/src/Form/ConfigForm.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Form;
 

--- a/modules/mongodb_watchdog/src/Form/OverviewFilterForm.php
+++ b/modules/mongodb_watchdog/src/Form/OverviewFilterForm.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Form;
 

--- a/modules/mongodb_watchdog/src/Install/Requirements.php
+++ b/modules/mongodb_watchdog/src/Install/Requirements.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Install;
 

--- a/modules/mongodb_watchdog/src/Install/SanityCheck.php
+++ b/modules/mongodb_watchdog/src/Install/SanityCheck.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\mongodb_watchdog\Install;
 
@@ -9,7 +9,7 @@ use Drupal\mongodb\DatabaseFactory;
 use Drupal\mongodb_watchdog\Logger;
 
 /**
- * Class SanityCheck.
+ * Class SanityCheck provides some reasonableness checks for MongoDB contents.
  *
  * @see \Drupal\mongodb_watchdog\Command\SanityCheckCommand
  * @see \Drupal\mongodb_watchdog\Commands\MongoDbWatchdogCommands::sanityCheck()

--- a/modules/mongodb_watchdog/tests/modules/mongodb_watchdog_test/mongodb_watchdog_test.module
+++ b/modules/mongodb_watchdog/tests/modules/mongodb_watchdog_test/mongodb_watchdog_test.module
@@ -1,10 +1,17 @@
 <?php
 
+/**
+ * @file
+ * Test support module.
+ *
+ * @see \Drupal\Tests\mongodb_watchdog\Unit\LoggerTest
+ */
+
 declare(strict_types=1);
 
-use Psr\Log\LoggerInterface;
-
 /**
+ * Create a stack trace specifically formatted to trigger issue 3219325.
+ *
  * @link https://www.drupal.org/project/mongodb/issues/3219325
  */
 function mongodb_watchdog_test_3219325(): array {

--- a/modules/mongodb_watchdog/tests/src/Functional/ControllerTest.php
+++ b/modules/mongodb_watchdog/tests/src/Functional/ControllerTest.php
@@ -15,21 +15,26 @@ use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Class ControllerTest.
+ * Test the MongoDB report controllers.
  *
  * @group MongoDB
  */
 class ControllerTest extends BrowserTestBase {
+
   use StringTranslationTrait;
 
   const DEFAULT_URI = 'mongodb://localhost:27017';
+
   const CLIENT_TEST_ALIAS = 'test';
 
   const DB_DEFAULT_ALIAS = 'default';
 
   const PATH_DENIED = '/admin/reports/mongodb/watchdog/access-denied';
+
   const PATH_EVENT_BASE = "/admin/reports/mongodb/watchdog/";
+
   const PATH_NOT_FOUND = '/admin/reports/mongodb/watchdog/page-not-found';
+
   const PATH_OVERVIEW = 'admin/reports/mongodb/watchdog';
 
   /**
@@ -139,23 +144,31 @@ class ControllerTest extends BrowserTestBase {
       ?? static::DEFAULT_URI;
 
     // This line customizes the parent site; ::writeSettings the child site.
-    $this->settings = new Settings([
-      MongoDb::MODULE => $this->getSettingsArray(),
-    ]);
+    $this->settings = new Settings(
+      [
+        MongoDb::MODULE => $this->getSettingsArray(),
+      ]
+    );
 
     parent::setUp();
 
     // Create users.
     $this->adminUser = $this->drupalCreateUser([], 'test_admin', TRUE);
-    $this->bigUser = $this->drupalCreateUser([
-      'administer site configuration',
-      'access administration pages',
-      'access site reports',
-      'administer users',
-    ], 'test_honcho');
-    $this->anyUser = $this->drupalCreateUser([
-      'access content',
-    ], 'test_lambda');
+    $this->bigUser = $this->drupalCreateUser(
+      [
+        'administer site configuration',
+        'access administration pages',
+        'access site reports',
+        'administer users',
+      ],
+      'test_honcho'
+    );
+    $this->anyUser = $this->drupalCreateUser(
+      [
+        'access content',
+      ],
+      'test_lambda'
+    );
 
     $this->requestTime = $this->container
       ->get('datetime.time')
@@ -226,7 +239,7 @@ class ControllerTest extends BrowserTestBase {
    * @return array
    *   A settings array only containing MongoDB-related settings.
    */
-  protected function getSettingsArray() : array {
+  protected function getSettingsArray(): array {
     return [
       'clients' => [
         static::CLIENT_TEST_ALIAS => [
@@ -236,8 +249,14 @@ class ControllerTest extends BrowserTestBase {
         ],
       ],
       'databases' => [
-        static::DB_DEFAULT_ALIAS => [static::CLIENT_TEST_ALIAS, $this->getDatabasePrefix()],
-        Logger::DB_LOGGER => [static::CLIENT_TEST_ALIAS, $this->getDatabasePrefix()],
+        static::DB_DEFAULT_ALIAS => [
+          static::CLIENT_TEST_ALIAS,
+          $this->getDatabasePrefix(),
+        ],
+        Logger::DB_LOGGER => [
+          static::CLIENT_TEST_ALIAS,
+          $this->getDatabasePrefix(),
+        ],
       ],
     ];
   }
@@ -250,7 +269,7 @@ class ControllerTest extends BrowserTestBase {
    *
    * @see \Drupal\KernelTests\KernelTestBase::getDatabasePrefix()
    */
-  protected function getDatabasePrefix() : string {
+  protected function getDatabasePrefix(): string {
     return $this->databasePrefix ?? '';
   }
 
@@ -260,7 +279,7 @@ class ControllerTest extends BrowserTestBase {
    * @return array
    *   List of entries and their information.
    */
-  protected function getLogEntries() : array {
+  protected function getLogEntries(): array {
     $entries = [];
     if ($table = $this->getLogsEntriesTable()) {
       /** @var \Behat\Mink\Element\NodeElement $row */
@@ -286,7 +305,7 @@ class ControllerTest extends BrowserTestBase {
    * @return int|null
    *   The watchdog severity constant or NULL if not found.
    */
-  protected function getSeverityConstant(string $class) : int {
+  protected function getSeverityConstant(string $class): int {
     // Class: "mongodb-watchdog__severity--(level)", prefix length = 28.
     $level = substr($class, 28);
     return static::LEVEL_TRANSLATION[$level];
@@ -298,7 +317,7 @@ class ControllerTest extends BrowserTestBase {
    * @return \Behat\Mink\Element\NodeElement[]
    *   The return value of a xpath search.
    */
-  protected function getLogsEntriesTable() : array {
+  protected function getLogsEntriesTable(): array {
     return $this->xpath('.//table/tbody/tr');
   }
 
@@ -311,7 +330,10 @@ class ControllerTest extends BrowserTestBase {
   protected function assertTypeCount(array $types) {
     $entries = $this->getLogEntries();
     $reducer = function ($accu, $curr) {
-      $accu[$curr['type'] . '-' . $curr['severity']] = [$curr['type'], $curr['severity']];
+      $accu[$curr['type'] . '-' . $curr['severity']] = [
+        $curr['type'],
+        $curr['severity'],
+      ];
       return $accu;
     };
     $actual = array_reduce($entries, $reducer, []);
@@ -339,13 +361,13 @@ class ControllerTest extends BrowserTestBase {
   ) {
     $ip = '::1';
     $context = [
-      'channel'     => $type,
-      'link'        => NULL,
-      'user'        => ['uid' => $this->bigUser->id()],
+      'channel' => $type,
+      'link' => NULL,
+      'user' => ['uid' => $this->bigUser->id()],
       'request_uri' => "http://[$ip]/",
-      'referer'     => $_SERVER['HTTP_REFERER'] ?? '',
-      'ip'          => $ip,
-      'timestamp'   => $this->requestTime,
+      'referer' => $_SERVER['HTTP_REFERER'] ?? '',
+      'ip' => $ip,
+      'timestamp' => $this->requestTime,
     ];
     $message = $this->randomString();
     for ($i = 0; $i < $count; $i++) {
@@ -463,7 +485,7 @@ class ControllerTest extends BrowserTestBase {
   /**
    * The access and contents of the admin/reports/mongodb/watchdog[/*] pages.
    *
-   * @TODO verifyRowLimit(), verifyCron(), verifyEvents() as per DbLog.
+   * @todo verifyRowLimit(), verifyCron(), verifyEvents() as per DbLog.
    */
   public function testLoggerReportsAccess() {
     $expectations = [
@@ -498,15 +520,21 @@ class ControllerTest extends BrowserTestBase {
     /** @var \Drupal\mongodb_watchdog\Logger $logger */
     $logger = $this->container->get(Logger::SERVICE_LOGGER);
     $templates = $logger->templateCollection();
-    $this->assertEquals(1, $templates->countDocuments(),
-      'Logging created templates collection and added a template to it.');
+    $this->assertEquals(
+      1,
+      $templates->countDocuments(),
+      'Logging created templates collection and added a template to it.'
+    );
 
     $template = $templates->findOne(['message' => $message], MongoDb::ID_PROJECTION);
     $this->assertNotNull($template, "Logged message was found: [${message}]");
     $templateId = $template['_id'];
     $events = $logger->eventCollection($templateId);
-    $this->assertEquals(1, $events->countDocuments(),
-      'Logging created events collection and added a template to it.');
+    $this->assertEquals(
+      1,
+      $events->countDocuments(),
+      'Logging created events collection and added a template to it.'
+    );
 
     // Login the admin user.
     $this->drupalLogin($this->adminUser);
@@ -526,8 +554,10 @@ class ControllerTest extends BrowserTestBase {
         . json_encode($messages);
     }
     $this->assertEquals(0, $count, $failMessage);
-    $this->assertFalse($logger->eventCollections()->valid(),
-      "Event collections were dropped");
+    $this->assertFalse(
+      $logger->eventCollections()->valid(),
+      "Event collections were dropped"
+    );
   }
 
   /**
@@ -574,9 +604,12 @@ class ControllerTest extends BrowserTestBase {
       $this->submitForm($edit, 'Filter');
 
       // Check whether the displayed event templates match our filter.
-      $filteredTypes = array_filter($types, function (array $type) use ($typeName) {
-        return $type['type'] === $typeName;
-      });
+      $filteredTypes = array_filter(
+        $types,
+        function (array $type) use ($typeName) {
+          return $type['type'] === $typeName;
+        }
+      );
       $this->assertTypeCount($filteredTypes);
     }
 
@@ -589,9 +622,12 @@ class ControllerTest extends BrowserTestBase {
       ];
       $this->submitForm($edit, 'Filter');
 
-      $filteredTypes = array_filter($types, function (array $type) use ($typeType, $typeSeverity) {
-        return $type['type'] === $typeType && $type['severity'] == $typeSeverity;
-      });
+      $filteredTypes = array_filter(
+        $types,
+        function (array $type) use ($typeType, $typeSeverity) {
+          return $type['type'] === $typeType && $type['severity'] == $typeSeverity;
+        }
+      );
 
       $this->assertTypeCount($filteredTypes);
     }

--- a/modules/mongodb_watchdog/tests/src/Kernel/LoggerTest.php
+++ b/modules/mongodb_watchdog/tests/src/Kernel/LoggerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb_watchdog\Kernel;
 
@@ -115,6 +115,22 @@ class LoggerTest extends MongoDbTestBase {
   protected function find($message) {
     $ret = $this->collection->findOne(['message' => $message]);
     return $ret;
+  }
+
+  /**
+   * Ensure logging from a closure does not fail.
+   *
+   * @covers ::enhanceLogEntry
+   *
+   * @see https://www.drupal.org/project/mongodb/issues/3193195
+   */
+  public function testLogClosure() {
+    $logger = $this->container->get(Logger::SERVICE_LOGGER);
+    $closure = function () use ($logger) {
+      $logger->notice("This fails on PHP below 7.0, and 5.6 needs to be supported for Drupal 8. The alcaeus adapter passes the version check, but does not address this.");
+      return 1;
+    };
+    $this->assertEquals(1, $closure());
   }
 
   /**

--- a/modules/mongodb_watchdog/tests/src/Unit/ControllerBaseTest.php
+++ b/modules/mongodb_watchdog/tests/src/Unit/ControllerBaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb_watchdog\Unit;
 
@@ -25,7 +25,7 @@ class ControllerBaseTest extends UnitTestCase {
    *
    * @dataProvider pageGenerationData
    */
-  public function testPageGeneration(int $requestedPage, float $count, int $expected) {
+  public function testPageGeneration(int $requestedPage, int $count, int $expected) {
     $actual = ControllerBase::getPage($count, $requestedPage, static::ITEMS_PER_PAGE);
     $this->assertEquals($expected, $actual);
   }
@@ -41,11 +41,11 @@ class ControllerBaseTest extends UnitTestCase {
     // One partial available page.
     $one = static::ITEMS_PER_PAGE;
     // Part of one page.
-    $partial = floor($one * 0.6);
+    $partial = (int) floor($one * 0.6);
     // More than one available page.
     $oneplus = $one + $partial;
     // Exactly two pages.
-    $two = $one * 2;
+    $two = (int) ($one * 2);
     $twoplus = $two + $partial;
 
     $expectations = [

--- a/modules/mongodb_watchdog/tests/src/Unit/LoggerTest.php
+++ b/modules/mongodb_watchdog/tests/src/Unit/LoggerTest.php
@@ -13,11 +13,16 @@ use PHPUnit\Framework\TestCase;
  */
 class LoggerTest extends TestCase {
 
+  /**
+   * {@inheritDoc}
+   */
   public function setUp(): void {
     require_once __DIR__ . "/../../modules/mongodb_watchdog_test/mongodb_watchdog_test.module";
   }
 
   /**
+   * Test for issue #3219325 about closures stack.
+   *
    * @link https://www.drupal.org/project/mongodb/issues/3219325
    * @covers ::enhanceLogEntry
    *
@@ -34,4 +39,5 @@ class LoggerTest extends TestCase {
       $this->fail($e->getMessage());
     }
   }
+
 }

--- a/modules/mongodb_watchdog/tests/src/Unit/MockLogger.php
+++ b/modules/mongodb_watchdog/tests/src/Unit/MockLogger.php
@@ -6,18 +6,30 @@ namespace Drupal\Tests\mongodb_watchdog\Unit;
 
 use Drupal\mongodb_watchdog\Logger;
 
+// Disable PHPCS which incorrectly diagnoses a useless constructor.
+// phpcs:disable
+
+/**
+ * Class MockLogger provides a Logger implementation usable in unit tests.
+ *
+ * Normal implementations would require a slower kernel Test.
+ *
+ * @package Drupal\Tests\mongodb_watchdog\Unit
+ */
 class MockLogger extends Logger {
 
   /**
    * TestLogger mock constructor.
    */
   public function __construct() {
+    // This override avoids requiring actual services.
   }
 
   /**
-   * @throws \ReflectionException
+   * {@inheritDoc}
    */
   public function enhanceLogEntry(array &$entry, array $backtrace): void {
     parent::enhanceLogEntry($entry, $backtrace);
   }
+
 }


### PR DESCRIPTION
- Also apply current (2021-01) Drupal coding standards.
- See https://www.drupal.org/project/mongodb/issues/3193195