### PR TITLE
Issue #3219325 by fgm, klelostec: support missing file info on functions

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,85 +1,176 @@
 filter:
-    paths:
-        - modules/mongodb/*
-        - modules/mongodb_watchdog/*
-        - example.settings.local.php
-    excluded_paths:
-        - '*.html.twig'
+  paths:
+    - modules/mongodb/*
+    - modules/mongodb_watchdog/*
+    - example.settings.local.php
+  excluded_paths:
+    - '*.html.twig'
 checks:
-    php:
-        code_rating: true
-        duplication: true
-        fix_php_opening_tag: true
-        remove_php_closing_tag: true
-        one_class_per_file: true
-        side_effects_or_types: true
-        no_mixed_inline_html: true
-        require_braces_around_control_structures: true
-        php5_style_constructor: true
-        no_global_keyword: false
-        avoid_usage_of_logical_operators: true
-        psr2_class_declaration: false
-        no_underscore_prefix_in_properties: true
-        no_underscore_prefix_in_methods: true
-        blank_line_after_namespace_declaration: true
-        single_namespace_per_use: true
-        psr2_switch_declaration: false
-        psr2_control_structure_declaration: false
-        avoid_superglobals: false
-        security_vulnerabilities: true
-        no_exit: true
-        use_self_instead_of_fqcn: true
-        uppercase_constants: true
-        simplify_boolean_return: true
-        return_doc_comments: true
-        return_doc_comment_if_not_inferrable: true
-        remove_extra_empty_lines: true
-        properties_in_camelcaps: true
-        prefer_while_loop_over_for_loop: true
-        parameter_doc_comments: true
-        param_doc_comment_if_not_inferrable: true
-        optional_parameters_at_the_end: true
-        no_short_variable_names:
-            minimum: '3'
-        no_short_method_names:
-            minimum: ''
-        no_new_line_at_end_of_file: false
-        no_long_variable_names:
-            maximum: '20'
-        no_goto: true
-        newline_at_end_of_file: true
-        more_specific_types_in_doc_comments: true
-        fix_use_statements:
-            remove_unused: true
-            preserve_multiple: false
-            preserve_blanklines: true
-            order_alphabetically: true
-        fix_line_ending: true
-        encourage_single_quotes: true
-        encourage_postdec_operator: true
-        coding_standard:
-            name: Drupal
-        classes_in_camel_caps: true
-        avoid_unnecessary_concatenation: true
-        avoid_perl_style_comments: true
-        avoid_multiple_statements_on_same_line: true
-        align_assignments: true
-    javascript: {  }
+  php:
+    code_rating: true
+    duplication: true
+    fix_php_opening_tag: true
+    remove_php_closing_tag: true
+    one_class_per_file: true
+    side_effects_or_types: true
+    no_mixed_inline_html: true
+    require_braces_around_control_structures: true
+    php5_style_constructor: true
+    no_global_keyword: false
+    avoid_usage_of_logical_operators: true
+    psr2_class_declaration: false
+    no_underscore_prefix_in_properties: true
+    no_underscore_prefix_in_methods: true
+    blank_line_after_namespace_declaration: true
+    single_namespace_per_use: true
+    psr2_switch_declaration: false
+    psr2_control_structure_declaration: false
+    avoid_superglobals: false
+    security_vulnerabilities: true
+    no_exit: true
+    use_self_instead_of_fqcn: true
+    uppercase_constants: true
+    simplify_boolean_return: true
+    return_doc_comments: true
+    return_doc_comment_if_not_inferrable: true
+    remove_extra_empty_lines: true
+    properties_in_camelcaps: true
+    prefer_while_loop_over_for_loop: true
+    parameter_doc_comments: true
+    param_doc_comment_if_not_inferrable: true
+    optional_parameters_at_the_end: true
+    no_short_variable_names:
+      minimum: '3'
+    no_short_method_names:
+      minimum: ''
+    no_new_line_at_end_of_file: false
+    no_long_variable_names:
+      maximum: '20'
+    no_goto: true
+    newline_at_end_of_file: true
+    more_specific_types_in_doc_comments: true
+    fix_use_statements:
+      remove_unused: true
+      preserve_multiple: false
+      preserve_blanklines: true
+      order_alphabetically: true
+    fix_line_ending: true
+    parameters_in_camelcaps: true
+    encourage_single_quotes: true
+    encourage_postdec_operator: true
+    coding_standard:
+      name: Drupal
+    classes_in_camel_caps: true
+    avoid_unnecessary_concatenation: true
+    avoid_perl_style_comments: true
+    avoid_multiple_statements_on_same_line: true
+    align_assignments: true
+  javascript: { }
 
 coding_style:
-    php:
-        braces:
-            if:
-                else_on_new_line: true
-            try:
-                catch_on_new_line: true
-                finally_on_new_line: true
-        indentation:
-            general:
-                size: 2
-        spaces:
-            around_operators:
-                concatenation: true
+  php:
+    indentation:
+      general:
+        use_tabs: false
+        size: 2
+      switch:
+        indent_case: true
+    spaces:
+      general:
+        linefeed_character: newline
+      before_parentheses:
+        function_declaration: false
+        closure_definition: true
+        function_call: false
+        if: true
+        for: true
+        while: true
+        switch: true
+        catch: true
+        array_initializer: false
+      around_operators:
+        assignment: true
+        logical: true
+        equality: true
+        relational: true
+        bitwise: true
+        additive: true
+        multiplicative: true
+        shift: true
+        unary_additive: false
+        concatenation: true
+        negation: false
+      before_left_brace:
+        class: true
+        function: true
+        if: true
+        else: true
+        for: true
+        while: true
+        do: true
+        switch: true
+        try: true
+        catch: true
+        finally: true
+      before_keywords:
+        else: true
+        while: true
+        catch: true
+        finally: true
+      within:
+        brackets: false
+        array_initializer: false
+        grouping: false
+        function_call: false
+        function_declaration: false
+        if: false
+        for: false
+        while: false
+        switch: false
+        catch: false
+        type_cast: false
+      ternary_operator:
+        before_condition: true
+        after_condition: true
+        before_alternative: true
+        after_alternative: true
+        in_short_version: false
+      other:
+        before_comma: false
+        after_comma: true
+        before_semicolon: false
+        after_semicolon: true
+        after_type_cast: true
+    braces:
+      classes_functions:
+        class: undefined
+        function: undefined
+        closure: undefined
+      if:
+        opening: undefined
+        always: true
+        else_on_new_line: true
+      for:
+        opening: undefined
+        always: true
+      while:
+        opening: undefined
+        always: true
+      do_while:
+        opening: undefined
+        always: true
+        while_on_new_line: false
+      switch:
+        opening: undefined
+      try:
+        opening: undefined
+        catch_on_new_line: true
+        finally_on_new_line: true
+    upper_lower_casing:
+      keywords:
+        general: undefined
+      constants:
+        true_false_null: undefined
 
 build:
   nodes:
@@ -89,6 +180,5 @@ build:
           - composer require --dev squizlabs/php_codesniffer:^3.5
       tests:
         override:
-          -
-            command: phpcs-run
+          - command: phpcs-run
             use_website_config: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ language: php
 sudo: true
 
 php:
-  - 7.3
   - 7.4
+  - 8.0
 
 services:
   - mongodb
 
 matrix:
-#  allow_failures:
-#    - php: 8.0
+  allow_failures:
+    - php: 8.0
   fast_finish: true
 
 env:
@@ -28,7 +28,7 @@ env:
     - PHPUNIT_OPTS="-c phpunit.xml -v --debug --coverage-clover=modules/contrib/$MODULE_NAME/$COVERAGE_FILE"
 
     # Code coverage via coveralls.io
-    - COVERALLS="php-coveralls/php-coveralls:2.1.*"
+    - COVERALLS="php-coveralls/php-coveralls:^2"
 
 cache:
   directories:
@@ -44,7 +44,7 @@ before_install:
   - sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
   - source $HOME/.bashrc
   # Force Composer 1 until all plugins support Composer 2.
-  - composer self-update --1
+  - composer self-update --2
 
   # Drush: 9.x prefers using a local version, so don't require it globally.
 
@@ -77,14 +77,14 @@ before_script:
   - cd ../..
 
   # download Drupal 9 core.
-  - wget -q -O - http://ftp.drupal.org/files/projects/drupal-9.1.x-dev.tar.gz | tar xz
-  - cd drupal-9.1.x-dev
+  - wget -q -O - https://ftp.drupal.org/files/projects/drupal-9.2.x-dev.tar.gz | tar xz
+  - cd drupal-9.2.x-dev
   - mkdir -p modules/contrib
   - mv ../fgm/mongodb modules/contrib
 
   # install dependencies (for the module) and Coveralls (for coverage) as part of the root vendors. Get rid of PHPunit < 7 and locked dependencies.
   - rm -fr composer.lock vendor
-  - composer require -v "drush/drush:^10" drupal/console "mongodb/mongodb:^1.4.0" "phpunit/phpunit:^7.5" $COVERALLS
+  - composer require -v "drush/drush:^10" drupal/console "mongodb/mongodb:^1.5.1" "phpunit/phpunit:^8.5" $COVERALLS
   - composer show mongodb/mongodb
 
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 INTRODUCTION
 ============
 
-MongoDB integration for Drupal, version 8.x-2.0-dev.
+MongoDB integration for Drupal 8.9.x and 9.x, version 8.x-2.0-dev.
 
 [![Build Status](https://travis-ci.org/fgm/mongodb.svg?branch=8.x-2.x)](https://travis-ci.org/fgm/mongodb)
 [![Coverage Status](https://coveralls.io/repos/github/fgm/mongodb/badge.svg?branch=8.x-2.x)](https://coveralls.io/github/fgm/mongodb?branch=8.x-2.x)

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,10 @@
     }
   ],
   "conflict": {
-    "composer/composer": "2.*",
-    "drupal/console": "< 1.8",
+    "drupal/core": "< 8.9.0",
     "drush/drush": "< 9.7"
   },
-  "description": "Drupal 9.1 driver for MongoDB",
+  "description": "Drupal 9.2 driver for MongoDB",
   "homepage": "https://www.drupal.org/project/mongodb",
   "keywords": ["drupal", "mongodb"],
   "license": "GPL-2.0-or-later",
@@ -39,8 +38,8 @@
   "support": {
     "docs": "https://github.com/fgm/mongodb/blob/8.x-2.x/README.md",
     "email": "support@osinet.fr",
-    "irc": "irc://chat.freenode.net:6697/drupal-mongodb",
-    "issues": "https://www.drupal.org/project/issues/mongodb",
+    "slack": "https://drupal.slack.com/archives/CCF6CGPEC",
+    "issues": "https://www.drupal.org/project/issues/mongodb?text=&status=Open&priorities=All&categories=All&version=all_8.x-2.*&component=All",
     "rss": "https://github.com/fgm/mongodb/commits/8.x-2.x.atom",
     "source": "https://github.com/fgm/mongodb/tree/8.x-2.x"
   },

--- a/core.phpunit.xml
+++ b/core.phpunit.xml
@@ -9,15 +9,9 @@
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
-         processIsolation="false">
-<!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
- https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
- result printer that links to the html output results for functional tests.
- Unfortunately, this breaks the output of PHPStorm's PHPUnit runner. However, if
- using the command line you can add
- - -printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" to use it (note there
- should be no spaces between the hyphens).
--->
+         failOnWarning="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
+         cacheResult="false">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -29,12 +23,19 @@
     <env name="SIMPLETEST_DB" value=""/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
     <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
-    <!-- To disable deprecation testing completely set SYMFONY_DEPRECATIONS_HELPER value: 'disabled' -->
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors"/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
   </php>
   <testsuites>
     <testsuite name="unit">
@@ -49,12 +50,12 @@
     <testsuite name="functional-javascript">
       <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
     </testsuite>
+    <testsuite name="build">
+      <file>./tests/TestSuites/BuildTestSuite.php</file>
+    </testsuite>
   </testsuites>
   <listeners>
     <listener class="\Drupal\Tests\Listeners\DrupalListener">
-    </listener>
-    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
-    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
     </listener>
   </listeners>
   <!-- Filter for coverage reports. -->

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,11 +6,11 @@ guide assumes that :
 
 * A [MongoDB][download] 4.0 to 4.2.x server instance has already been installed,
   configured and is available for connection from the Drupal instance.
-* The site will be running [Drupal][drupal] 8.8.x or 8.9.x, with [Drush][drush]
+* The site will be running [Drupal][drupal] 8.9.x or 9.x.y, with [Drush][drush]
   10.x.
 * The [mongodb][mongodb] (not [mongo][mongo]) PHP extension version 1.7 or
   later is installed and configured.
-* PHP is version 7.2.x to 7.3.x. PHP 7.4.x might work but is not tested: be sure
+* PHP is version 7.3.x to 8.0.x. PHP 8.0.x should work but is not tested: be sure
   to [report any issue][report] you could have with it.
 * We recommend [using Composer](#installing-using-composer) for installing this
   module.
@@ -47,7 +47,7 @@ by the [free monitoring][freemonitoring] service offered by MongoDB Inc.
 ## Settings Configuration
 
 * Download the module package, as per
-  [Installing contributed modules (Drupal 8)][install]
+  [Installing contributed modules (Drupal 8/9)][install]
 * Copy the relevant section from `mongodb/example.settings.local.php` to your
   `settings.local.php` file if you use one, or `settings.php` otherwise,
   and adapt it to match your MongoDB settings. These settings are used by the

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -37,7 +37,7 @@ instance themselves.
     class FooTest extends MongoDbTestBase {
       const MODULE = 'foo';
 
-      public static $modules = [
+      protected static $modules = [
         MongoDb::MODULE,
         static::MODULE,
       ];
@@ -66,7 +66,7 @@ instance themselves.
        * If the tests do not need a specific database, no setUp()/tearDown() is
        * even needed.
        */
-      public function setUp() {
+      public function setUp(): void {
         parent::setUp();
         $this->database = new DatabaseFactory(
           new ClientFactory($this->settings),
@@ -80,7 +80,7 @@ instance themselves.
        * If the tests do not need a specific database, no setUp()/tearDown() is
        * even needed.
        */
-      public function tearDown() {
+      public function tearDown(): void {
         $this->database->drop();
         parent::tearDown();
       }

--- a/modules/mongodb/tests/src/Kernel/DatabaseFactoryTest.php
+++ b/modules/mongodb/tests/src/Kernel/DatabaseFactoryTest.php
@@ -23,7 +23,7 @@ class DatabaseFactoryTest extends MongoDbTestBase {
    *
    * @var array
    */
-  public static $modules = [MongoDb::MODULE];
+  protected static $modules = [MongoDb::MODULE];
 
   /**
    * The mongodb.client_factory service.
@@ -42,7 +42,7 @@ class DatabaseFactoryTest extends MongoDbTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->clientFactory = new ClientFactory($this->settings);
     $this->databaseFactory = new DatabaseFactory($this->clientFactory, $this->settings);

--- a/modules/mongodb/tests/src/Kernel/MongoDbTestBase.php
+++ b/modules/mongodb/tests/src/Kernel/MongoDbTestBase.php
@@ -30,7 +30,7 @@ abstract class MongoDbTestBase extends KernelTestBase {
    *
    * @var array
    */
-  public static $modules = [MongoDb::MODULE];
+  protected static $modules = [MongoDb::MODULE];
 
   /**
    * A test-specific instance of Settings.
@@ -90,7 +90,7 @@ abstract class MongoDbTestBase extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     // $_ENV if it comes from phpunit.xml <env>
     // $_SERVER if it comes from the phpunit command line environment.
@@ -104,7 +104,7 @@ abstract class MongoDbTestBase extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function tearDown() {
+  public function tearDown(): void {
     $clientFactory = new ClientFactory($this->settings);
     $databaseFactory = new DatabaseFactory($clientFactory, $this->settings);
     $databaseFactory->get(static::DB_DEFAULT_ALIAS)

--- a/modules/mongodb_storage/tests/src/Kernel/KeyValueTestBase.php
+++ b/modules/mongodb_storage/tests/src/Kernel/KeyValueTestBase.php
@@ -17,16 +17,34 @@ use Drupal\Tests\mongodb\Kernel\MongoDbTestBase;
  * @group MongoDB
  */
 abstract class KeyValueTestBase extends MongoDbTestBase {
+  const MAGIC = 'mongodb.nonexistent';
 
   /**
    * Modules to enable.
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     MongoDb::MODULE,
     Storage::MODULE,
   ];
+
+  public function setUp(): void {
+    parent::setUp();
+
+    // Force creation of KV tables after https://www.drupal.org/node/3143286
+    /** @var \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $kvpf */
+    $kvpf = $this->container->get('keyvalue.database');
+    $kvp = $kvpf->get(self::MAGIC);
+    $kvp->set(self::MAGIC, self::MAGIC);
+    $kvp->deleteAll();
+
+    /** @var \Drupal\Core\KeyValueStore\KeyValueExpirableFactoryInterface $kvef */
+    $kvef = $this->container->get('keyvalue.expirable.database');
+    $kve = $kvef->get(self::MAGIC);
+    $kve->set(self::MAGIC, self::MAGIC);
+    $kve->deleteAll();
+  }
 
   /**
    * {@inheritdoc}

--- a/modules/mongodb_watchdog/mongodb_watchdog.info.yml
+++ b/modules/mongodb_watchdog/mongodb_watchdog.info.yml
@@ -3,7 +3,7 @@ core_version_requirement: ^8 || ^9
 dependencies:
   - mongodb:mongodb
 description: 'A logger (watchdog) implementation using MongoDB'
-name: 'MongoDB watchdog'
+name: 'MongoDB Watchdog'
 package: 'MongoDB'
 php: '7.x'
 type: 'module'

--- a/modules/mongodb_watchdog/src/Controller/ControllerBase.php
+++ b/modules/mongodb_watchdog/src/Controller/ControllerBase.php
@@ -157,7 +157,7 @@ abstract class ControllerBase extends CoreControllerBase {
    * @return int
    *   The actual index of the page to display.
    */
-  public static function getPage(int $count, int $requestedPage, int $height): int {
+  public static function getPage(float $count, int $requestedPage, int $height): int {
     if ($requestedPage <= 0) {
       return 0;
     }

--- a/modules/mongodb_watchdog/tests/modules/mongodb_watchdog_test/mongodb_watchdog_test.info.yml
+++ b/modules/mongodb_watchdog/tests/modules/mongodb_watchdog_test/mongodb_watchdog_test.info.yml
@@ -1,0 +1,6 @@
+name: 'MongoDB Watchdog test support'
+type: module
+description: 'Module to test the MongoDB Watchdog Logger.'
+package: MongoDB
+hidden: true
+core_version_requirement: ^8|^9

--- a/modules/mongodb_watchdog/tests/modules/mongodb_watchdog_test/mongodb_watchdog_test.module
+++ b/modules/mongodb_watchdog/tests/modules/mongodb_watchdog_test/mongodb_watchdog_test.module
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * @link https://www.drupal.org/project/mongodb/issues/3219325
+ */
+function mongodb_watchdog_test_3219325(): array {
+  // See \Drupal\mongodb_watchdog\Logger::log()
+  $bt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+  // Fake XDebug being unable to locate the file.
+  unset($bt[0]['file']);
+  return $bt;
+}

--- a/modules/mongodb_watchdog/tests/src/Functional/ControllerTest.php
+++ b/modules/mongodb_watchdog/tests/src/Functional/ControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\mongodb_watchdog\Functional;
 
@@ -131,7 +131,7 @@ class ControllerTest extends BrowserTestBase {
    *
    * @see \Drupal\Tests\mongodb_watchdog\Functional\ControllerTest::writeSettings()
    */
-  public function setUp() {
+  public function setUp(): void {
     // $_ENV if it comes from phpunit.xml <env>
     // $_SERVER if it comes from the phpunit command line environment.
     $this->uri = $_ENV['MONGODB_URI']
@@ -176,7 +176,7 @@ class ControllerTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public function tearDown() {
+  public function tearDown(): void {
     // Get the database before container is torn down.
     $database = $this->container
       ->get(MongoDb::SERVICE_DB_FACTORY)
@@ -511,7 +511,8 @@ class ControllerTest extends BrowserTestBase {
     // Login the admin user.
     $this->drupalLogin($this->adminUser);
     // Now post to clear the db table.
-    $this->drupalPostForm('admin/reports/mongodb/confirm', [], 'Confirm');
+    $this->drupalGet('admin/reports/mongodb/confirm');
+    $this->submitForm([], 'Confirm');
 
     // Make the sure logs were dropped. After a UI clear, the templates
     // collection should exist, since it is recreated as a capped collection as
@@ -570,7 +571,7 @@ class ControllerTest extends BrowserTestBase {
       $edit = [
         'type[]' => [$typeName],
       ];
-      $this->drupalPostForm(NULL, $edit, 'Filter');
+      $this->submitForm($edit, 'Filter');
 
       // Check whether the displayed event templates match our filter.
       $filteredTypes = array_filter($types, function (array $type) use ($typeName) {
@@ -586,7 +587,7 @@ class ControllerTest extends BrowserTestBase {
         'type[]' => $typeType = $type['type'],
         'severity[]' => $typeSeverity = $type['severity'],
       ];
-      $this->drupalPostForm(NULL, $edit, 'Filter');
+      $this->submitForm($edit, 'Filter');
 
       $filteredTypes = array_filter($types, function (array $type) use ($typeType, $typeSeverity) {
         return $type['type'] === $typeType && $type['severity'] == $typeSeverity;

--- a/modules/mongodb_watchdog/tests/src/Kernel/LoggerTest.php
+++ b/modules/mongodb_watchdog/tests/src/Kernel/LoggerTest.php
@@ -32,7 +32,7 @@ class LoggerTest extends MongoDbTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     MongoDb::MODULE,
     Logger::MODULE,
@@ -41,7 +41,7 @@ class LoggerTest extends MongoDbTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->installConfig(Logger::MODULE);
   }

--- a/modules/mongodb_watchdog/tests/src/Unit/ControllerBaseTest.php
+++ b/modules/mongodb_watchdog/tests/src/Unit/ControllerBaseTest.php
@@ -25,7 +25,7 @@ class ControllerBaseTest extends UnitTestCase {
    *
    * @dataProvider pageGenerationData
    */
-  public function testPageGeneration(int $requestedPage, int $count, int $expected) {
+  public function testPageGeneration(int $requestedPage, float $count, int $expected) {
     $actual = ControllerBase::getPage($count, $requestedPage, static::ITEMS_PER_PAGE);
     $this->assertEquals($expected, $actual);
   }

--- a/modules/mongodb_watchdog/tests/src/Unit/LoggerTest.php
+++ b/modules/mongodb_watchdog/tests/src/Unit/LoggerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\Tests\mongodb_watchdog\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the ControllerBase mechanisms.
+ *
+ * @coversDefaultClass \Drupal\mongodb_watchdog\Logger
+ *
+ * @group mongodb
+ */
+class LoggerTest extends TestCase {
+
+  public function setUp(): void {
+    require_once __DIR__ . "/../../modules/mongodb_watchdog_test/mongodb_watchdog_test.module";
+  }
+
+  /**
+   * @link https://www.drupal.org/project/mongodb/issues/3219325
+   * @covers ::enhanceLogEntry
+   *
+   * @throws \ReflectionException
+   */
+  public function testEnhanceLogEntry() {
+    $backtrace = mongodb_watchdog_test_3219325();
+    $logger = new MockLogger();
+    $entry = [];
+    try {
+      $logger->enhanceLogEntry($entry, $backtrace);
+    }
+    catch (\ReflectionException $e) {
+      $this->fail($e->getMessage());
+    }
+  }
+}

--- a/modules/mongodb_watchdog/tests/src/Unit/MockLogger.php
+++ b/modules/mongodb_watchdog/tests/src/Unit/MockLogger.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mongodb_watchdog\Unit;
+
+use Drupal\mongodb_watchdog\Logger;
+
+class MockLogger extends Logger {
+
+  /**
+   * TestLogger mock constructor.
+   */
+  public function __construct() {
+  }
+
+  /**
+   * @throws \ReflectionException
+   */
+  public function enhanceLogEntry(array &$entry, array $backtrace): void {
+    parent::enhanceLogEntry($entry, $backtrace);
+  }
+}


### PR DESCRIPTION
In some php/xdebug configurations, the file information may be missing on plain functions. Support it.

Issue: https://www.drupal.org/project/mongodb/issues/3219325